### PR TITLE
Escape special characters like quotes

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -118,7 +118,7 @@ function send_neighborhood() {
 	$.ajax({
 		type : "POST",
 		url : endpoint + '/add',
-		data : $( this ).serialize(),
+		data : escapeSpecialCharacters( $( this ).serialize() ),
 		success: function( data, status ) {
 			$( "#ajax-loading" ).hide();
 			$( "#ajax-success b").text( data );
@@ -154,6 +154,17 @@ function check_cookie(){
 		user = uuid.v1();
 		$.cookie( 'bcworkshop-collect', user, { path: '/' } );
 	}
+}
+
+function escapeSpecialCharacters(text) {
+  var map = {
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  
+  return text.replace(/[<>"']/g, function(m) { return map[m]; });
 }
 
 init();


### PR DESCRIPTION
Escapes brackets, quotes, and double quotes.

I couldn't find a jquery or javascript method for escaping quotes. So I borrowed a replacement method from StackOverflow.
